### PR TITLE
Remove texticle reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@
       <h2 class="subsection">Limit Searched Columns with Searchable</h2>
       <div>
         <p>If you don't wish to search across all your text columns, you an include Searchable with a list of columns to whitelist in searches:</p>
-        <script src="https://gist.github.com/1074349.js?file=searchable_example.rb"></script>
+        <script src="https://gist.github.com/5054142.js?file=searchable_example.rb"></script>
         <p>As you can see, _why can't be found.</p>
       </div>
       <h2 class="subsection">Scope Searches</h2>


### PR DESCRIPTION
Texticle is referenced in a gist in the [documentation](http://textacular.github.com/textacular/#gist1074349). It's probably best to just update the gist, so that the documentation continues to only include gists from @ecin's account, but here's a PR for the change just in case.
