### PR TITLE
Use Model.all instead of Model.scope deprecated in Rails 4.

### DIFF
--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -145,7 +145,7 @@ module Textacular
   def assemble_query(similarities, conditions, exclusive)
     rank = connection.quote_column_name('rank' + rand.to_s)
 
-    select("#{quoted_table_name + '.*,' if scoped.select_values.empty?} #{similarities.join(" + ")} AS #{rank}").
+    select("#{quoted_table_name + '.*,' if all.select_values.empty?} #{similarities.join(" + ")} AS #{rank}").
       where(conditions.join(exclusive ? " AND " : " OR ")).
       order("#{rank} DESC")
   end


### PR DESCRIPTION
Simple little fix to remove a deprecation warning under Rails 4.

I haven't researched backwards compatibility with Rails 3.x or how to possibly offer it, but I'd be glad to discuss it here.

More about this here: http://blog.remarkablelabs.com/2012/12/what-s-new-in-active-record-rails-4-countdown-to-2013
