### PR TITLE
Fix Rails 4 deprecation warnings for scoped and references

### DIFF
--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -145,8 +145,9 @@ module Textacular
   def assemble_query(similarities, conditions, exclusive)
     rank = connection.quote_column_name('rank' + rand.to_s)
 
-    select("#{quoted_table_name + '.*,' if scoped.select_values.empty?} #{similarities.join(" + ")} AS #{rank}").
+    select("#{quoted_table_name + '.*,' if all.select_values.empty?} #{similarities.join(" + ")} AS #{rank}").
       where(conditions.join(exclusive ? " AND " : " OR ")).
+      references("#{quoted_table_name}, #{rank}").
       order("#{rank} DESC")
   end
 


### PR DESCRIPTION
Did not get tests running so this could break rails 3.2 given use of all instead of scoped - probably not the safest way to fix but submitting for discussion.
