### PR TITLE
Remove the unnecessary normalize

### DIFF
--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -82,7 +82,7 @@ module Textacular
         results += parse_query_hash(search_term, column_or_table)
       else
         column = connection.quote_column_name(column_or_table)
-        search_term = connection.quote normalize(Helper.normalize(search_term))
+        search_term = connection.quote Helper.normalize(search_term)
 
         results << [table_name, column, search_term]
       end
@@ -148,10 +148,6 @@ module Textacular
     select("#{quoted_table_name + '.*,' if scoped.select_values.empty?} #{similarities.join(" + ")} AS #{rank}").
       where(conditions.join(exclusive ? " AND " : " OR ")).
       order("#{rank} DESC")
-  end
-
-  def normalize(query)
-    query
   end
 
   def searchable_columns


### PR DESCRIPTION
The `normalize` method was just passing through the query value. No need for the extra stack level.
