### PR TITLE
fix documentation, :require => textacular/rails in gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ extending ActiveRecord with scopes making search easy and fun!
 In the project's Gemfile add
 
 ```ruby
-gem 'textacular', '~> 3.0'
+gem 'textacular', '~> 3.0', :require => 'textacular/rails'
 ```
 
 #### ActiveRecord outside of Rails


### PR DESCRIPTION
Textacular was not loading in rails 3.2.13 until `:require => 'textacular/rails'` was included in the Gemfile. I adjusted the documentation to reflect this.
