### PR TITLE
How can I use this awesome gem along with the include method?

### DIFF
--- a/spec/textacular/searchable_spec.rb
+++ b/spec/textacular/searchable_spec.rb
@@ -98,6 +98,10 @@ class SearchableTest < Test::Unit::TestCase
       should "allow includes" do
         assert_equal [@penny], WebComicWithSearchableNameAndAuthor.includes(:characters).advanced_search("Penny")
       end
+
+      should "allow includes" do
+        assert_equal [@penny], WebComicWithSearchableNameAndAuthor.includes(:characters).basic_search('Penny').where(:characters => { :name => 'Div' })
+      end
     end
   end
 end


### PR DESCRIPTION
For example i did this:
`articles = Article.advanced_search("something")`

but then i wanna include another tables to that results

`articles.order("articles.updated_at DESC").includes(:sites, :article_types, :targets)`

But i just get an error, because the rank column isn't present, for example:
`ActiveRecord::StatementInvalid: PGError: ERROR:  column "rank0.83464760137993" does not exist`

Any ideas?
