### PR TITLE
Remove Dynamic Search Methods?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Fix dependency loading for textacular rake tasks.
 * Fix ranking failures when rows had `NULL` column values.
 * Clean up Rakefile; should make developing the gem nicer.
+* DEPRECATION: The dynamic search helpers will be removed at the next major
+  release.
 
 ## 3.0.0
 

--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -38,6 +38,7 @@ module Textacular
   def method_missing(method, *search_terms)
     return super if self.abstract_class?
     if Helper.dynamic_search_method?(method, self.columns)
+      warn("You are using a dynamic Textacular search method #{method}. These methods are deprecated and will be removed at the next major version release. Please use the has syntax for basic_search and advanced_search.")
       exclusive = Helper.exclusive_dynamic_search_method?(method, self.columns)
       columns = exclusive ? Helper.exclusive_dynamic_search_columns(method) : Helper.inclusive_dynamic_search_columns(method)
       metaclass = class << self; self; end


### PR DESCRIPTION
As brought up in #15, messing with `method_missing` can be hairy and have unexpected and hard-to-debug consequences. The feature that we're using `method_missing` to support is the dynamic search methods (like `Game.search_by_title("fighter")`). Personally, I've never used this feature. And I feel like these _kinds_ of features are falling out of favor in the community in general.

Do you use this feature? Would you be sad to see it go? I'd love to hear from both other maintainers as well as users.

Obviously, this would require a major version bump to release, so I'm thinking we'd add a deprecation warning to some patch release and then rev to 4.0 before ripping it out, if that's the path we decide one.
