### PR TITLE
Checking the Postgres module directory is not necessary on postgres 9.1.x

### DIFF
--- a/lib/textacular/postgres_module_installer.rb
+++ b/lib/textacular/postgres_module_installer.rb
@@ -45,12 +45,6 @@ module Textacular
     end
 
     def install_postgres_91_module(module_name)
-      module_location = "#{postgres_share_dir}/extension/#{module_name}.control"
-
-      unless system("ls #{module_location}")
-        raise RuntimeError, "Cannot find the #{module_name} module. Was it compiled and installed?"
-      end
-
       ActiveRecord::Base.connection.execute("CREATE EXTENSION #{module_name};")
     end
   end

--- a/lib/textacular/tasks.rb
+++ b/lib/textacular/tasks.rb
@@ -11,7 +11,6 @@ namespace :textacular do
   desc "Install trigram text search module"
   task :install_trigram => [:environment] do
     installer = Textacular::PostgresModuleInstaller.new
-    installer.install_module('fuzzystrmatch')
     installer.install_module('pg_trgm')
 
     puts "Trigram text search module successfully installed into '#{installer.db_name}' database."


### PR DESCRIPTION
I have tested by running `rake textacular:install_trigram` and verified that it works when connected to another host running Postgres 9.1.9.
