### PR TITLE
It do not play well with AR#pluck

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ extending ActiveRecord with scopes making search easy and fun!
 ## FEATURES/PROBLEMS:
 
 * Only works with PostgreSQL
+* Anything that mucks with the `SELECT` statement (notably `pluck`), is likely
+  to [cause problems](https://github.com/textacular/textacular/issues/28).
 
 
 ## SYNOPSIS:


### PR DESCRIPTION
Hi,

Querying like this:

``` ruby
User.search('Roger').pluck(:name)
```

Will result in an `ActiveRecord::StatementInvalid` error.

The issue is that pluck override the select clause so the `ORDER BY "rank1234567"` clause just don't work.
