### PR TITLE
Fallback to zero similarity when trying to match null values

### DIFF
--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -141,7 +141,7 @@ module Textacular
   end
 
   def fuzzy_similarity_string(table_name, column, search_term)
-    "similarity(#{table_name}.#{column}, #{search_term})"
+    "COALESCE(similarity(#{table_name}.#{column}, #{search_term}), 0.0)"
   end
 
   def fuzzy_condition_string(table_name, column, search_term)

--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -141,7 +141,7 @@ module Textacular
   end
 
   def fuzzy_similarity_string(table_name, column, search_term)
-    "COALESCE(similarity(#{table_name}.#{column}, #{search_term}), 0.0)"
+    "COALESCE(similarity(#{table_name}.#{column}, #{search_term}), 0)"
   end
 
   def fuzzy_condition_string(table_name, column, search_term)

--- a/spec/textacular/searchable_spec.rb
+++ b/spec/textacular/searchable_spec.rb
@@ -68,7 +68,7 @@ class SearchableTest < Test::Unit::TestCase
         qcont_with_author = @qcont.becomes(WebComicWithSearchableNameAndAuthor)
         search_result = WebComicWithSearchableNameAndAuthor.fuzzy_search('Questio')
         assert_equal [qcont_with_author], search_result
-        assert_kind_of Numeric, search_result.first.attributes.find { |k, _| k[0..3] == 'rank' }.last
+        assert_kind_of Float, search_result.first.attributes.find { |k, _| k[0..3] == 'rank' }.last
       end
 
       should "define :searchable_columns as private" do

--- a/spec/textacular/searchable_spec.rb
+++ b/spec/textacular/searchable_spec.rb
@@ -31,7 +31,7 @@ class SearchableTest < Test::Unit::TestCase
 
     context "with one column as parameter" do
       setup do
-        @qcont = WebComicWithSearchableName.create :name => "Questionable Content", :author => "Jeph Jaques"
+        @qcont = WebComicWithSearchableName.create :name => "Questionable Content", :author => nil
         @jhony = WebComicWithSearchableName.create :name => "Johnny Wander", :author => "Ananth & Yuko"
         @ddeeg = WebComicWithSearchableName.create :name => "Dominic Deegan", :author => "Mookie"
         @penny = WebComicWithSearchableName.create :name => "Penny Arcade", :author => "Tycho & Gabe"
@@ -62,6 +62,13 @@ class SearchableTest < Test::Unit::TestCase
 
       should "fuzzy search stuff" do
         assert_equal [@qcont], WebComicWithSearchableName.fuzzy_search('Questio')
+      end
+
+      should "fuzzy return a valid rank when fuzzy searching on NULL columns" do
+        qcont_with_author = @qcont.becomes(WebComicWithSearchableNameAndAuthor)
+        search_result = WebComicWithSearchableNameAndAuthor.fuzzy_search('Questio')
+        assert_equal [qcont_with_author], search_result
+        assert_kind_of Numeric, search_result.first.attributes.find { |k, _| k[0..3] == 'rank' }.last
       end
 
       should "define :searchable_columns as private" do


### PR DESCRIPTION
PostgreSQL will return a NULL when it's calculating the similarity of a string with a NULL value so wrap the similarity calculation inside a coalesce to make it fall back to 0.0 similarity when comparing with NULL values.