### PR TITLE
create extension only if not exists

### DIFF
--- a/lib/textacular/trigram_installer.rb
+++ b/lib/textacular/trigram_installer.rb
@@ -3,7 +3,7 @@ class Textacular::TrigramInstaller
     content = <<-MIGRATION
 class InstallTrigram < ActiveRecord::Migration
   def self.up
-    ActiveRecord::Base.connection.execute("CREATE EXTENSION pg_trgm;")
+    ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
   end
 
   def self.down

--- a/spec/textacular/trigram_installer_spec.rb
+++ b/spec/textacular/trigram_installer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Textacular::TrigramInstaller" do
     <<-MIGRATION
 class InstallTrigram < ActiveRecord::Migration
   def self.up
-    ActiveRecord::Base.connection.execute("CREATE EXTENSION pg_trgm;")
+    ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
   end
 
   def self.down


### PR DESCRIPTION
I just started a new project which uses apartment and postgres schemas for multitenancy. When I run the migrations it is trying to run the trigram installer for each tenant, which throws an error if the extension is already installed.