### PR TITLE
fix advanced search negation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix search term escaping
 * Trigram installation migration only install extension if not installed yet.
 * Update the README to illustrate how to change the similarity threshold.
 

--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -179,7 +179,7 @@ module Textacular
   module Helper
     class << self
       def normalize(query)
-        query.to_s.gsub(' ', '\\\\ ')
+        query.to_s.gsub(/\s(?![\&|\!|\|])/, '\\\\ ')
       end
 
       def method_name_regex

--- a/spec/textacular/searchable_spec.rb
+++ b/spec/textacular/searchable_spec.rb
@@ -108,6 +108,9 @@ RSpec.describe "Searchable" do
             }.to raise_error(ActiveRecord::StatementInvalid)
           end
         end
+        it "searches with negation" do
+          expect(WebComicWithSearchableName.advanced_search('foo & ! bar')).to be_empty
+        end
       end
 
       it "does fuzzy searching" do


### PR DESCRIPTION
This one closes #76 
The problem was the way textacular escapes multi word strings. Before this patch any space character was escaped but actually we should only escape a space if it's followed by anything else than `! & |` (we don't support advanced queries with those characters. at least there is a test for that.).