### PR TITLE
Change name of rank + random number to textacular_rank instead, to have it accessible.

### DIFF
--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -121,7 +121,7 @@ module Textacular
   end
 
   def assemble_query(similarities, conditions, exclusive)
-    rank = connection.quote_column_name('rank' + rand(100000000000000000).to_s)
+    rank = connection.quote_column_name('textacular_rank')
 
     select("#{quoted_table_name + '.*,' if select_values.empty?} #{similarities.join(" + ")} AS #{rank}").
       where(conditions.join(exclusive ? " AND " : " OR ")).


### PR DESCRIPTION
To me, the randomization of the `rank` name is complete overkill. There is no reason for this just to avoid column name collisions. We could just give it a less generic name than `rank` e.g. `textacular_rank`. This will make it accessible for after processing in ruby.

``` ruby
result = Model.fuzzy_search("query")
result.map(&: textacular_rank) #=> [1.3343, 0.798, 0.76432]
```
