### PR TITLE
Correct the arguments order in FullTextIndexer#generate_migration

### DIFF
--- a/lib/textacular/full_text_indexer.rb
+++ b/lib/textacular/full_text_indexer.rb
@@ -16,7 +16,7 @@ class #{model_name}FullTextSearch < ActiveRecord::Migration
 end
 MIGRATION
     filename = "#{model_name.underscore}_full_text_search"
-    generator = Textacular::MigrationGenerator.new(content, filename)
+    generator = Textacular::MigrationGenerator.new(filename, content)
     generator.generate_migration
   end
 


### PR DESCRIPTION
FullTextIndexer was calling MigrationGenerator with arguments reverse raising a Errno::ENAMETOOLONG exception.
They are now passed in the right order.