### PR TITLE
Pass dictionnary as single quoted string to to_tsvector

### DIFF
--- a/lib/textacular/full_text_indexer.rb
+++ b/lib/textacular/full_text_indexer.rb
@@ -52,7 +52,7 @@ MIGRATION
     <<-SQL
 CREATE index #{index_name_for(model, column)}
   ON #{model.table_name}
-  USING gin(to_tsvector("#{dictionary}", "#{model.table_name}"."#{column}"::text));
+  USING gin(to_tsvector('#{dictionary}', "#{model.table_name}"."#{column}"::text));
 SQL
   end
 


### PR DESCRIPTION
to_tsvector first parameter is a string (or at least can be) and so need to be single quoted,
double quotes trigger PG::UndefinedColumn: ERROR:  column "english" does not exist.