### PR TITLE
Allow fuzzy searching of non-text columns (and fix broken tests on master)

### DIFF
--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -113,11 +113,11 @@ module Textacular
   end
 
   def fuzzy_similarity_string(table_name, column, search_term)
-    "COALESCE(similarity(#{table_name}.#{column}, #{search_term}), 0)"
+    "COALESCE(similarity(#{table_name}.#{column}::text, #{search_term}), 0)"
   end
 
   def fuzzy_condition_string(table_name, column, search_term)
-    "(#{table_name}.#{column} % #{search_term})"
+    "(#{table_name}.#{column}::text % #{search_term})"
   end
 
   def assemble_query(similarities, conditions, exclusive)

--- a/spec/textacular_spec.rb
+++ b/spec/textacular_spec.rb
@@ -181,6 +181,13 @@ RSpec.describe Textacular do
         expect(GameExtendedWithTextacular).to respond_to(:search)
       end
 
+      describe "#fuzzy_search" do
+        it 'searches non-text columns' do
+          expect(GameExtendedWithTextacular.fuzzy_search(id: mario.id)
+          ).to eq([mario])
+        end
+      end
+
       describe "#advanced_search" do
         context "with a String argument" do
           it "searches across all :string columns (if not indexes have been specified)" do


### PR DESCRIPTION
For example when you use `search(integer_column: some_value)`, the similarity function was complaining that it doesn't take `(integer, string)`.

This also fixes two incorrect tests on master.