### PR TITLE
Drop support for ruby-1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.2.5
   - 2.1.10
   - 2.0.0
-  - 1.9.3-p551
 env:
   - DB=postgresql
 before_install:


### PR DESCRIPTION
- Remove it from .travis.yml

The `pg` gem doesn't support 1.9.3, so `textacular` should probably not be bothered. 

https://travis-ci.org/textacular/textacular/jobs/178547682

```
Gem::InstallError: pg requires Ruby version >= 2.0.0.
```

Also, on master we're getting 

```activesupport-5.0.0.1 requires ruby version >= 2.2.2, which is incompatible with the current version, ruby 2.1.10p492```

Might be worth moving up to `2.2.2` minimum?

Let me know and I'll open a PR?