### PR TITLE
Allow ActiveRecord 5.1.x

### DIFF
--- a/textacular.gemspec
+++ b/textacular.gemspec
@@ -63,5 +63,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-doc'
 
-  s.add_dependency('activerecord', [">= 3.0", "<= 5.1"])
+  s.add_dependency('activerecord', [">= 3.0", "< 5.2"])
 end


### PR DESCRIPTION
ActiveRecord 5.1 worked, but not 5.1.1