### PR TITLE
Fixes Rails 5.2.0 deprecation and change Travis-setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-  - 2.3.1
-  - 2.2.5
+  - 2.5.0
+  - 2.4.3
+  - 2.3.6
+  - 2.2.9
 env:
   - DB=postgresql
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 * ActiveRecord 5.2 compatibility by wrapping string queries with `Arel.sql()`
+* Adds latest Ruby, Rails and Postgres-dependencies to Travis.
+* Rewrite development migration code to support Rails 5.0-5.2.
 
 ## 5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* ActiveRecord 5.2 compatibility by wrapping string queries with `Arel.sql()`
+
 ## 5.0.0
 
 * ActiveRecord 5.1 compatibility

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'activerecord', '~> 5.2.x'

--- a/Rakefile
+++ b/Rakefile
@@ -43,12 +43,22 @@ namespace :db do
 
     desc 'Run the test database migrations'
     task :up => :'db:connect' do
-      ActiveRecord::Migrator.up 'db/migrate'
+      migrations = if ActiveRecord.version.version >= '5.2'
+        ActiveRecord::Migration.new.migration_context.migrations
+      else
+        ActiveRecord::Migrator.migrations('db/migrate')
+      end
+      ActiveRecord::Migrator.new(:up, migrations, nil).migrate
     end
 
     desc 'Reverse the test database migrations'
     task :down => :'db:connect' do
-      ActiveRecord::Migrator.down 'db/migrate'
+      migrations = if ActiveRecord.version.version >= '5.2'
+        ActiveRecord::Migration.new.migration_context.migrations
+      else
+        ActiveRecord::Migrator.migrations('db/migrate')
+      end
+      ActiveRecord::Migrator.new(:down, migrations, nil).migrate
     end
   end
   task :migrate => :'migrate:up'

--- a/gemfiles/activerecord-5.0.gemfile
+++ b/gemfiles/activerecord-5.0.gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec :path=>"../"
+gemspec path: "../"
 
-gem 'activerecord', '~> 5.0.x'
+gem 'activerecord', '>= 5.0', '< 5.1'
+gem 'pg', '~> 0.21'

--- a/gemfiles/activerecord-5.1.gemfile
+++ b/gemfiles/activerecord-5.1.gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec :path=>"../"
 
-gem 'activerecord', '~> 5.1.x'
+gem 'activerecord', '< 5.2', '>= 5.1'

--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -123,9 +123,9 @@ module Textacular
   def assemble_query(similarities, conditions, exclusive)
     rank = connection.quote_column_name('rank' + rand(100000000000000000).to_s)
 
-    select("#{quoted_table_name + '.*,' if select_values.empty?} #{similarities.join(" + ")} AS #{rank}").
+    select(Arel.sql("#{quoted_table_name + '.*,' if select_values.empty?} #{similarities.join(" + ")} AS #{rank}")).
       where(conditions.join(exclusive ? " AND " : " OR ")).
-      order("#{rank} DESC")
+      order(Arel.sql("#{rank} DESC"))
   end
 
   def select_values

--- a/textacular.gemspec
+++ b/textacular.gemspec
@@ -56,12 +56,12 @@ Gem::Specification.new do |s|
   ]
   s.require_paths = ['lib']
 
-  s.add_development_dependency 'pg', '~> 0.14'
+  s.add_development_dependency 'pg', '~> 1.0.0'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-doc'
 
-  s.add_dependency('activerecord', [">= 3.0", "< 5.2"])
+  s.add_dependency('activerecord', [">= 5.0", "< 5.3"])
 end


### PR DESCRIPTION
# Contents
- Addresses issue #120 and Rails 5.2 deprecations.
- Use ActiveRecord 5.2.x as the default Gemfile, adds Gemfiles for 5.0.x and 5.1.x
- Adds the currently supported ruby versions to Travis matrix, based on [ruby-lang.org](https://www.ruby-lang.org/en/downloads/)

## Disclaimer
I do not know if the `Arel.sql()` solution  is good, but it was the best solution I could come up with.