### PR TITLE
Allow custom rank alias.

### DIFF
--- a/lib/textacular.rb
+++ b/lib/textacular.rb
@@ -12,29 +12,29 @@ module Textacular
     'english'
   end
 
-  def search(query = "", exclusive = true)
-    basic_search(query, exclusive)
+  def search(query = "", exclusive = true, rank_alias = nil)
+    basic_search(query, exclusive, rank_alias)
   end
 
-  def basic_search(query = "", exclusive = true)
+  def basic_search(query = "", exclusive = true, rank_alias = nil)
     exclusive, query = munge_exclusive_and_query(exclusive, query)
     parsed_query_hash = parse_query_hash(query)
     similarities, conditions = basic_similarities_and_conditions(parsed_query_hash)
-    assemble_query(similarities, conditions, exclusive)
+    assemble_query(similarities, conditions, exclusive, rank_alias)
   end
 
-  def advanced_search(query = "", exclusive = true)
+  def advanced_search(query = "", exclusive = true, rank_alias = nil)
     exclusive, query = munge_exclusive_and_query(exclusive, query)
     parsed_query_hash = parse_query_hash(query)
     similarities, conditions = advanced_similarities_and_conditions(parsed_query_hash)
-    assemble_query(similarities, conditions, exclusive)
+    assemble_query(similarities, conditions, exclusive, rank_alias)
   end
 
-  def fuzzy_search(query = '', exclusive = true)
+  def fuzzy_search(query = '', exclusive = true, rank_alias = nil)
     exclusive, query = munge_exclusive_and_query(exclusive, query)
     parsed_query_hash = parse_query_hash(query)
     similarities, conditions = fuzzy_similarities_and_conditions(parsed_query_hash)
-    assemble_query(similarities, conditions, exclusive)
+    assemble_query(similarities, conditions, exclusive, rank_alias)
   end
 
   private
@@ -120,8 +120,9 @@ module Textacular
     "(#{table_name}.#{column}::text % #{search_term})"
   end
 
-  def assemble_query(similarities, conditions, exclusive)
-    rank = connection.quote_column_name('rank' + rand(100000000000000000).to_s)
+  def assemble_query(similarities, conditions, exclusive, rank_alias)
+    rank_alias ||= 'rank' + rand(100000000000000000).to_s
+    rank = connection.quote_column_name(rank_alias)
 
     select(Arel.sql("#{quoted_table_name + '.*,' if select_values.empty?} #{similarities.join(" + ")} AS #{rank}")).
       where(conditions.join(exclusive ? " AND " : " OR ")).

--- a/spec/textacular/searchable_spec.rb
+++ b/spec/textacular/searchable_spec.rb
@@ -190,5 +190,34 @@ RSpec.describe "Searchable" do
         ).to eq([penny_arcade])
       end
     end
+
+    context 'custom rank' do
+      let!(:questionable_content) do
+        WebComicWithSearchableName.create(
+          name: 'Questionable Content',
+          author: nil,
+        )
+      end
+
+      it "is selected for search" do
+        search_result = WebComicWithSearchableNameAndAuthor.search('Questionable Content', true, 'my_rank')
+        expect(search_result.first.attributes['my_rank']).to be_truthy
+      end
+
+      it "is selected for basic_search" do
+        search_result = WebComicWithSearchableNameAndAuthor.basic_search('Questionable Content', true, 'my_rank')
+        expect(search_result.first.attributes['my_rank']).to be_truthy
+      end
+
+      it "is selected for advanced_search" do
+        search_result = WebComicWithSearchableNameAndAuthor.advanced_search('Questionable Content', true, 'my_rank')
+        expect(search_result.first.attributes['my_rank']).to be_truthy
+      end
+
+      it "is selected for fuzzy_search" do
+        search_result = WebComicWithSearchableNameAndAuthor.fuzzy_search('Questionable Content', true, 'my_rank')
+        expect(search_result.first.attributes['my_rank']).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
Non-overlaping rank alias name is great to solve one kind of edge situation as described in https://github.com/textacular/textacular/commit/2d5fc5c19e3ee4e106f5b8f1f4f47018556c2274 (`Game.search(:title => "Sonic).search(:system => "Game Gear")`). Anyway I think there is no reason to not expose it under user control when needed.

## example

```ruby
WebComicWithSearchableNameAndAuthor.fuzzy_search('Questionable Content', true, 'my_rank')
```

```sql
SELECT "web_comics".*,
       COALESCE(similarity("web_comics"."name"::text, 'Questionable\ Content'), 0) + COALESCE(similarity("web_comics"."author"::text, 'Questionable\ Content'), 0) AS "my_rank"
FROM "web_comics"
WHERE (("web_comics"."name"::text % 'Questionable\ Content')
       OR ("web_comics"."author"::text % 'Questionable\ Content'))
ORDER BY "my_rank" DESC
LIMIT $1
```

This can potentially fix #87, #88 as well