### PR TITLE
Update README.md getting started -- latest rails versions first

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,18 @@ extending ActiveRecord with scopes making search easy and fun!
 
 ### Quick Start
 
+In the project's Gemfile add
+
+```ruby
+gem 'textacular', '~> 5.0'
+```
+
 #### Rails 3, Rails 4
 
 In the project's Gemfile add
 
 ```ruby
 gem 'textacular', '~> 4.0'
-```
-
-#### Rails > 5.0
-
-In the project's Gemfile add
-
-```ruby
-gem 'textacular', '~> 5.0'
 ```
 
 #### ActiveRecord outside of Rails


### PR DESCRIPTION
Change the order of the getting started instruction to first show the latest versions of rails. Older (and no longer supported) versions of rails should be more of a side-note.