### PR TITLE
Actually allow rails 7

### DIFF
--- a/textacular.gemspec
+++ b/textacular.gemspec
@@ -64,5 +64,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-doc'
   s.add_development_dependency 'byebug'
 
-  s.add_dependency('activerecord', [">= 5.0", "< 7.0"])
+  s.add_dependency 'activerecord', '>= 5.0'
 end


### PR DESCRIPTION
The AR dependency is restricted below 7, probably a typo `<` instead of `<=` https://github.com/textacular/textacular/pull/144/files#diff-5ac6210bca2b88149d742991d388abf2f279819f387228bd8954b77dfe70f3e4R67 

It would be nice, if a max limit can be defended, the defense is documented. This is asserting the gem is not compatible which is probably not true.  Otherwise it's a PITA going around forking gems because of these arbitrary pins