### PR TITLE
Fixes version in 7.0 gemfile

### DIFF
--- a/gemfiles/activerecord-7.0.gemfile
+++ b/gemfiles/activerecord-7.0.gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec :path=>"../"
 
-gem 'activerecord', '< 6.2', '>= 6.1'
+gem 'activerecord', '< 7.1', '>= 7.0'
 gem "pg", ">= 0.18", "< 2.0"


### PR DESCRIPTION
I noticed that the added Gemfile for Rails 7.0 uses Rails 6.1 instead, this PR fixes this issue.