### PR TITLE
Readd Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,5 @@
 name: Main
-on:
-  push:
+on: [push, pull_request]
 
 jobs:
   base:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0]
+        ruby: [2.7, '3.0', 3.1]
     name: Gemfile - Ruby ${{ matrix.ruby }}
     services:
       postgres:


### PR DESCRIPTION
Rails 7 is now compatible with Ruby 3.1, for versions of Rails >= 7.0.1.  Re-adding Ruby 3.1/Rails 7 to the CI matrix.