### PR TITLE
ActiveRecord 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [3.0, 3.1, 3.2]
-        rails: ['6.0', '6.1', '7.0']
+        rails: ['6.0', '6.1', '7.0', '7.1']
         include:
           - rails: '5.0'
             ruby: 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* ActiveRecord 7.1 compatibility
+
 ## 5.5.1
 
 * Revert breaking change to fuzzy_search introduced in 49f09b389d2f2b18cbe9de565b7ac5fcac14d7c6

--- a/gemfiles/activerecord-7.1.gemfile
+++ b/gemfiles/activerecord-7.1.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec :path=>"../"
+
+gem 'activerecord', '< 7.2', '>= 7.1'
+gem 'activesupport', '< 7.2', '>= 7.1'
+gem "pg", ">= 0.18", "< 2.0"

--- a/textacular.gemspec
+++ b/textacular.gemspec
@@ -66,5 +66,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-doc'
   s.add_development_dependency 'byebug'
 
-  s.add_dependency('activerecord', [">= 5.0", "< 7.1"])
+  s.add_dependency('activerecord', [">= 5.0", "< 7.2"])
 end


### PR DESCRIPTION
Extend the build matrix and widen the dependency constraints to support ActiveRecord 7.1.

Locally no code changes were needed to get Textacular's test suite passing with ActiveRecord 7.1.