### PR TITLE
Defer extending ActiveRecord::Base until Active Record is loaded

### DIFF
--- a/lib/textacular/rails.rb
+++ b/lib/textacular/rails.rb
@@ -4,7 +4,9 @@ require File.expand_path(File.dirname(__FILE__) + '/../textacular')
 module Textacular
   class Railtie < Rails::Railtie
     initializer "textacular.configure_rails_initialization" do
-      ActiveRecord::Base.extend(Textacular)
+      ActiveSupport.on_load(:active_record) do
+        ActiveRecord::Base.extend(Textacular)
+      end
     end
 
     rake_tasks do


### PR DESCRIPTION
This PR adds a load hook to ensure that Textacular does not prematurely load/require `ActiveRecord::Base`. This will speed up development boot speed and avoid potential clashing with Rails reloading/autoloading behavior.