### PR TITLE
Update textacular.gemspec

### DIFF
--- a/textacular.gemspec
+++ b/textacular.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license  = 'MIT'
   s.authors  = ['Ben Hamill', 'ecin', 'Aaron Patterson', 'Greg Molnar']
   s.email    = ['git-commits@benhamill.com', 'ecin@copypastel.com']
-  s.homepage = 'http://textacular.github.com/textacular'
+  s.homepage = 'https://github.com/textacular/textacular'
 
   s.files = [
     'CHANGELOG.md',


### PR DESCRIPTION
Replaces broken homepage link in gemspec with a link to the GitHub repo so that the "homepage" link on RubyGems.org goes to a valid page.